### PR TITLE
update to newer sdk

### DIFF
--- a/src/steam_wrapper.cpp
+++ b/src/steam_wrapper.cpp
@@ -51,9 +51,9 @@ extern "C" void c_SteamAPI_RunCallbacks()
 	return SteamAPI_RunCallbacks();
 }
 
-extern "C" bool c_SteamGameServer_Init(uint32_t unIP, uint16_t usSteamPort, uint16_t usGamePort, uint16_t usQueryPort, c_EServerMode eServerMode, const char* pchVersionString)
+extern "C" bool c_SteamGameServer_Init(uint32_t unIP, uint16_t usGamePort, uint16_t usQueryPort, c_EServerMode eServerMode, const char* pchVersionString)
 {
-	return SteamGameServer_Init(unIP, usSteamPort, usGamePort, usQueryPort, static_cast<EServerMode>(eServerMode), pchVersionString);
+	return SteamGameServer_Init(unIP, usGamePort, usQueryPort, static_cast<EServerMode>(eServerMode), pchVersionString);
 }
 
 extern "C" void c_SteamGameServer_Shutdown()
@@ -86,9 +86,9 @@ extern "C" void c_SteamGameServer_LogOnAnonymous()
 	SteamGameServer()->LogOnAnonymous();
 }
 
-extern "C" void c_SteamGameServer_EnableHeartbeats(bool bActive)
+extern "C" void c_SteamGameServer_SetAdvertiseServerActive(bool bActive)
 {
-	SteamGameServer()->EnableHeartbeats(bActive);
+	SteamGameServer()->SetAdvertiseServerActive(bActive);
 }
 
 extern "C" void c_SteamGameServer_LogOff()
@@ -143,7 +143,7 @@ extern "C" bool c_SteamGameServer_BSecure()
 
 extern "C" void c_SteamGameServer_SendUserDisconnect(void* steamIDUser)
 {
-	SteamGameServer()->SendUserDisconnect(*static_cast<CSteamID *>(steamIDUser));
+	SteamGameServer()->SendUserDisconnect_DEPRECATED(*static_cast<CSteamID *>(steamIDUser));
 }
 
 extern "C" void c_SteamGameServer_RunCallbacks()

--- a/src/steam_wrapper.cpp
+++ b/src/steam_wrapper.cpp
@@ -30,6 +30,11 @@ extern "C" void c_SteamAPI_Shutdown()
 	SteamAPI_Shutdown();
 }
 
+extern "C" bool c_SteamAPI_IsSteamRunning()
+{
+	return SteamAPI_IsSteamRunning();
+}
+
 extern "C" bool c_SteamAPI_RestartAppIfNecessary(uint32_t unOwnAppID)
 {
 	return SteamAPI_RestartAppIfNecessary(unOwnAppID);

--- a/src/steam_wrapper.h
+++ b/src/steam_wrapper.h
@@ -26,7 +26,7 @@ typedef enum c_EServerMode_t
 	c_eServerModeAuthenticationAndSecure = 3,
 } c_EServerMode;
 
-bool c_SteamGameServer_Init(uint32_t unIP, uint16_t usSteamPort, uint16_t usGamePort, uint16_t usQueryPort, c_EServerMode eServerMode, const char* pchVersionString);
+bool c_SteamGameServer_Init(uint32_t unIP, uint16_t usGamePort, uint16_t usQueryPort, c_EServerMode eServerMode, const char* pchVersionString);
 
 void c_SteamGameServer_Shutdown();
 
@@ -50,7 +50,7 @@ void c_SteamGameServer_SetGameDescription(const char *pszGameDescription);
 
 void c_SteamGameServer_LogOnAnonymous();
 
-void c_SteamGameServer_EnableHeartbeats(bool bActive);
+void c_SteamGameServer_SetAdvertiseServerActive(bool bActive);
 
 void c_SteamGameServer_LogOff();
 

--- a/src/steam_wrapper.h
+++ b/src/steam_wrapper.h
@@ -20,6 +20,8 @@ bool c_SteamAPI_Init();
 
 void c_SteamAPI_Shutdown();
 
+bool c_SteamAPI_IsSteamRunning();
+
 bool c_SteamAPI_RestartAppIfNecessary(uint32_t unOwnAppID);
 
 bool c_SteamUser_BLoggedOn();

--- a/src/steam_wrapper.h
+++ b/src/steam_wrapper.h
@@ -6,6 +6,14 @@
 #ifndef STEAM_WRAPPER_H
 #define STEAM_WRAPPER_H
 
+#ifndef EXTERN
+#ifdef _STEAM_EXTERN
+#define EXTERN extern
+#else
+#define EXTERN
+#endif
+#endif
+
 #include <stdint.h>
 
 bool c_SteamAPI_Init();
@@ -443,13 +451,13 @@ void* c_P2PSessionRequest_t_m_steamIDRemote(void *P2PSessionRequest_t_instance);
  * Function pointers to handle steam callbacks.
  * NOTE: You'll have to implement these yourself. But first, call c_SteamServerWrapper_Instantiate().
  */
-void (*c_SteamServerWrapper_OnSteamServersConnected)(void *pLogonSuccess);
-void (*c_SteamServerWrapper_OnSteamServersConnectFailure)(void *pConnectFailure);
-void (*c_SteamServerWrapper_OnSteamServersDisconnected)(void *pLoggedOff);
-void (*c_SteamServerWrapper_OnPolicyResponse)(void *pPolicyResponse);
-void (*c_SteamServerWrapper_OnValidateAuthTicketResponse)(void *pResponse);
-void (*c_SteamServerWrapper_OnP2PSessionRequest)(void *p_Callback);
-void (*c_SteamServerWrapper_OnP2PSessionConnectFail)(void *pCallback);
+EXTERN void (*c_SteamServerWrapper_OnSteamServersConnected)(void *pLogonSuccess);
+EXTERN void (*c_SteamServerWrapper_OnSteamServersConnectFailure)(void *pConnectFailure);
+EXTERN void (*c_SteamServerWrapper_OnSteamServersDisconnected)(void *pLoggedOff);
+EXTERN void (*c_SteamServerWrapper_OnPolicyResponse)(void *pPolicyResponse);
+EXTERN void (*c_SteamServerWrapper_OnValidateAuthTicketResponse)(void *pResponse);
+EXTERN void (*c_SteamServerWrapper_OnP2PSessionRequest)(void *p_Callback);
+EXTERN void (*c_SteamServerWrapper_OnP2PSessionConnectFail)(void *pCallback);
 
 /*
  * NOTE: Call c_SteamServerWrapper_Destroy() when you're done using this to free the memory.
@@ -496,26 +504,26 @@ void* c_ValidateAuthTicketResponse_t_m_SteamID(void *ValidateAuthTicketResponse_
  * Function Pointers to handle steam callbacks.
  * NOTE: You'll have to implement these yourself. But first, call c_SteamServerClientWrapper_Instantiate().
  */
-void (*c_SteamServerClientWrapper_OnLobbyDataUpdate)(void *pCallback);
-void (*c_SteamServerClientWrapper_OnLobbyGameCreated)(void *pCallback);
-void (*c_SteamServerClientWrapper_OnGameJoinRequested)(void *pCallback);
-void (*c_SteamServerClientWrapper_OnAvatarImageLoaded)(void *pCallback);
-void (*c_SteamServerClientWrapper_OnSteamServersConnected)(void *callback);
-void (*c_SteamServerClientWrapper_OnSteamServersDisconnected)(void *callback);
-void (*c_SteamServerClientWrapper_OnSteamServerConnectFailure)(void *callback);
-void (*c_SteamServerClientWrapper_OnGameOverlayActivated)(void *callback);
-void (*c_SteamServerClientWrapper_OnGameWebCallback)(void *callback);
-void (*c_SteamServerClientWrapper_OnWorkshopItemInstalled)(void *pParam);
-void (*c_SteamServerClientWrapper_OnP2PSessionConnectFail)(void *pCallback);
-void (*c_SteamServerClientWrapper_OnP2PSessionRequest)(void *pCallback);
-void (*c_SteamServerClientWrapper_OnIPCFailure)(void *failure);
-void (*c_SteamServerClientWrapper_OnSteamShutdown)(void *callback);
-void (*c_SteamServerClientWrapper_OnLobbyCreated)(void *pCallback, bool bIOFailure); //Where pCallback is a pointer to type LobbyCreated_t.
-void (*c_SteamServerClientWrapper_OnLobbyEntered)(void *pCallback, bool bIOFailure); //Where pCallback is a pointer to type LobbyEnter_t.
-void (*c_SteamServerClientWrapper_OnLobbyMatchListCallback)(void *pCallback, bool bIOFailure); //Where pCallback is a pointer to type LobbyMatchList_t.
-void (*c_SteamServerClientWrapper_OnRequestEncryptedAppTicket)(void *pEncryptedAppTicketResponse, bool bIOFailure); //Where pEncryptedAppTicketResponse is of type EncryptedAppTicketResponse_t.
+EXTERN void (*c_SteamServerClientWrapper_OnLobbyDataUpdate)(void *pCallback);
+EXTERN void (*c_SteamServerClientWrapper_OnLobbyGameCreated)(void *pCallback);
+EXTERN void (*c_SteamServerClientWrapper_OnGameJoinRequested)(void *pCallback);
+EXTERN void (*c_SteamServerClientWrapper_OnAvatarImageLoaded)(void *pCallback);
+EXTERN void (*c_SteamServerClientWrapper_OnSteamServersConnected)(void *callback);
+EXTERN void (*c_SteamServerClientWrapper_OnSteamServersDisconnected)(void *callback);
+EXTERN void (*c_SteamServerClientWrapper_OnSteamServerConnectFailure)(void *callback);
+EXTERN void (*c_SteamServerClientWrapper_OnGameOverlayActivated)(void *callback);
+EXTERN void (*c_SteamServerClientWrapper_OnGameWebCallback)(void *callback);
+EXTERN void (*c_SteamServerClientWrapper_OnWorkshopItemInstalled)(void *pParam);
+EXTERN void (*c_SteamServerClientWrapper_OnP2PSessionConnectFail)(void *pCallback);
+EXTERN void (*c_SteamServerClientWrapper_OnP2PSessionRequest)(void *pCallback);
+EXTERN void (*c_SteamServerClientWrapper_OnIPCFailure)(void *failure);
+EXTERN void (*c_SteamServerClientWrapper_OnSteamShutdown)(void *callback);
+EXTERN void (*c_SteamServerClientWrapper_OnLobbyCreated)(void *pCallback, bool bIOFailure); //Where pCallback is a pointer to type LobbyCreated_t.
+EXTERN void (*c_SteamServerClientWrapper_OnLobbyEntered)(void *pCallback, bool bIOFailure); //Where pCallback is a pointer to type LobbyEnter_t.
+EXTERN void (*c_SteamServerClientWrapper_OnLobbyMatchListCallback)(void *pCallback, bool bIOFailure); //Where pCallback is a pointer to type LobbyMatchList_t.
+EXTERN void (*c_SteamServerClientWrapper_OnRequestEncryptedAppTicket)(void *pEncryptedAppTicketResponse, bool bIOFailure); //Where pEncryptedAppTicketResponse is of type EncryptedAppTicketResponse_t.
 
-void (*c_SteamServerClientWrapper_GameServerPingOnServerResponded)(void *steamID);
+EXTERN void (*c_SteamServerClientWrapper_GameServerPingOnServerResponded)(void *steamID);
 
 /*
  * NOTE: Call c_SteamServerClientWrapper_Destroy() when you're done using this to free to memory.


### PR DESCRIPTION
SteamGameServer_Init no longer uses usSteamPort.
SteamGameServer_EnableHeartbeats was renamed.
SteamGameServer_SendUserDisconnect is now deprecated.